### PR TITLE
Add more encoding support when reading captions

### DIFF
--- a/captions.js
+++ b/captions.js
@@ -8,6 +8,9 @@
 * @returns An instance of the node-captions module.
 */
 
+var iconv = require('iconv-lite');
+iconv.extendNodeEncodings();
+
 module.exports = {
     scc: require('./lib/scc.js'),
     srt: require('./lib/srt.js'),

--- a/lib/scc.js
+++ b/lib/scc.js
@@ -22,9 +22,9 @@ module.exports = {
      * @param {callback} callback - WHen the read is successful callback.
      * @public
      */
-    read: function (file, callback) {
+    read: function (file, options, callback) {
         var lines;
-        fs.readFile(file, function (err, data) {
+        fs.readFile(file, options, function (err, data) {
             if (err) {
                 //err
                 return callback(err);

--- a/lib/srt.js
+++ b/lib/srt.js
@@ -57,8 +57,8 @@ module.exports = {
      * @param {callback} callback - callback to call when complete
      * @public
      */
-    read: function (file, callback) {
-        fs.readFile(file, function (err, data) {
+    read: function (file, options, callback) {
+        fs.readFile(file, options, function (err, data) {
             if (err) {
                 return callback(err);
             }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Jason Rojas <jason@nothingbeatsaduck.com>",
   "license": "MIT",
   "dependencies": {
+    "iconv-lite": "^0.4.4",
     "moment": "^2.6.0"
   },
   "devDependencies": {

--- a/test/scc-test.js
+++ b/test/scc-test.js
@@ -6,7 +6,7 @@ describe('Reading SCC file', function () {
         readErr;
 
     before(function(done) {
-        captions.scc.read('./test/captions/test.scc', function(err, data) {
+        captions.scc.read('./test/captions/test.scc', {}, function(err, data) {
             if (err) { throw 'ERROR Reading test SCC file: ' + err; }
             SCCFile = data;
             done();
@@ -14,14 +14,14 @@ describe('Reading SCC file', function () {
     });
 
     it('should error if file doesnt exist', function(done) {
-        captions.scc.read('nosuchfile', function(err, data) {
+        captions.scc.read('nosuchfile', {}, function(err, data) {
             should.exist(err);
             done();
         });
     });
 
     it('should error if file is bad', function(done) {
-        captions.scc.read('./test/captions/test.srt', function(err, data) {
+        captions.scc.read('./test/captions/test.srt', {}, function(err, data) {
             err.should.equal('INVALID_SCC_FORMAT');
             done();
         });

--- a/test/smi-test.js
+++ b/test/smi-test.js
@@ -7,7 +7,7 @@ describe('Read SCC file, generate SAMI', function () {
         samiFile;
 
     before(function(done) {
-        captions.scc.read('./test/captions/test.scc', function(err, data) {
+        captions.scc.read('./test/captions/test.scc', {}, function(err, data) {
             if (err) { throw 'ERROR Reading test SCC file: ' + err; }
             SCCFile = data;
             jsonObj = captions.scc.toJSON(data);

--- a/test/smpte_tt-test.js
+++ b/test/smpte_tt-test.js
@@ -7,7 +7,7 @@ describe('Read SCC file, generate SMPTE-TT', function () {
         smpte_ttFile;
 
     before(function(done) {
-        captions.scc.read('./test/captions/test.scc', function(err, data) {
+        captions.scc.read('./test/captions/test.scc', {}, function(err, data) {
             if (err) { throw 'ERROR Reading test SCC file: ' + err; }
             SCCFile = data;
             jsonObj = captions.scc.toJSON(data);

--- a/test/srt-test.js
+++ b/test/srt-test.js
@@ -8,7 +8,7 @@ describe('Reading SRT file', function () {
         readErr;
 
     before(function(done) {
-        captions.srt.read('./test/captions/test.srt', function(err, data) {
+        captions.srt.read('./test/captions/test.srt', {}, function(err, data) {
             if (err) { throw 'ERROR Reading test SRT file: ' + err; }
             SRTFile = data;
             badSRTFile = 'BAD FILE';
@@ -17,13 +17,13 @@ describe('Reading SRT file', function () {
         });
     });
     it ('should err out', function(done) {
-        captions.srt.read('./nofileexists', function(err, data) {
+        captions.srt.read('./nofileexists', {}, function(err, data) {
             should.exist(err);
             done();
         });
     });
     it ('should be an invalid format err', function(done) {
-        captions.srt.read('./test/captions/test.scc', function(err, data) {
+        captions.srt.read('./test/captions/test.scc', {}, function(err, data) {
             err.should.equal('INVALID_SRT_FORMAT');
             done();
         });

--- a/test/time-test.js
+++ b/test/time-test.js
@@ -7,7 +7,7 @@ describe('Read SCC file, adjust time', function () {
         jsonObj;
 
     before(function(done) {
-        captions.scc.read('./test/captions/time-test.scc', function(err, data) {
+        captions.scc.read('./test/captions/time-test.scc', {}, function(err, data) {
             if (err) { throw 'ERROR Reading test SCC file: ' + err; }
             SCCFile = data;
             jsonObj = captions.scc.toJSON(data);
@@ -29,7 +29,7 @@ describe('Read SCC file, adjust time', function () {
     });
 
     it('the first time code should be 1 hour more', function(done) {
-        captions.scc.read('./test/captions/time-test.scc', function(err, data) {
+        captions.scc.read('./test/captions/time-test.scc', {}, function(err, data) {
             captions.time.adjust('3600', 'seconds', captions.scc.toJSON(data), function (err, adjustedCaptions) {
                 if (err) { throw 'ERROR ADJUSTING CAPTIONS: ' + err;}
                 var oldTime = original[0].startTimeMicro;

--- a/test/ttml-test.js
+++ b/test/ttml-test.js
@@ -7,7 +7,7 @@ describe('Read SCC file, generate TTML', function () {
         ttmlFile;
 
     before(function(done) {
-        captions.scc.read('./test/captions/test.scc', function(err, data) {
+        captions.scc.read('./test/captions/test.scc', {}, function(err, data) {
             if (err) { throw 'ERROR Reading test SCC file: ' + err; }
             SCCFile = data;
             jsonObj = captions.scc.toJSON(data);

--- a/test/vtt-test.js
+++ b/test/vtt-test.js
@@ -9,7 +9,7 @@ describe('Read SCC file, generate VTT', function () {
         vttHour;
 
     before(function(done) {
-        captions.scc.read('./test/captions/test.scc', function(err, data) {
+        captions.scc.read('./test/captions/test.scc', {}, function(err, data) {
             if (err) { throw 'ERROR Reading test SCC file: ' + err; }
             SCCFile = data;
             jsonObj = captions.scc.toJSON(data);


### PR DESCRIPTION
Adds an extra argument to `read`.These options are then passed to the `fs.readFile` methods in each of the lib files. Also adds iconv-lite to allow for more encodings

Fixes #6 
