### PR TITLE
Fixes possible omission of first subtitle

### DIFF
--- a/lib/srt.js
+++ b/lib/srt.js
@@ -155,7 +155,7 @@ module.exports = {
                 startTimeMicro = module.exports.translateTime(time[0]);
                 endTimeMicro = module.exports.translateTime(time[1]);
                 durationMicro = parseInt(parseInt(endTimeMicro, 10) - parseInt(startTimeMicro, 10), 10);
-                if (!startTimeMicro || !endTimeMicro) {
+                if (isNaN(startTimeMicro) || isNaN(endTimeMicro)) {
                     // no valid timestamp
                     index++;
                     continue;


### PR DESCRIPTION
- If the subtitles start at 00:00:00,000, then the srt.toJSON
  will think it's an invalid timestamp
