### PR TITLE
Fix zero time subtitle missing bug

### DIFF
--- a/lib/srt.js
+++ b/lib/srt.js
@@ -155,7 +155,7 @@ module.exports = {
                 startTimeMicro = module.exports.translateTime(time[0]);
                 endTimeMicro = module.exports.translateTime(time[1]);
                 durationMicro = parseInt(parseInt(endTimeMicro, 10) - parseInt(startTimeMicro, 10), 10);
-                if (!startTimeMicro || !endTimeMicro) {
+                if (isNaN(startTimeMicro) || isNaN(endTimeMicro)) {
                     // no valid timestamp
                     index++;
                     continue;


### PR DESCRIPTION
Fix the bug that, if startTimeMicro or endTimeMicro is zero (00:00:00,000) in the srt file, the conversion will skip that subtitle